### PR TITLE
Create ParsingAnIISSMTPLog

### DIFF
--- a/Log Analytics/ParsingAnIISSMTPLog
+++ b/Log Analytics/ParsingAnIISSMTPLog
@@ -1,0 +1,2 @@
+SMTPLogs_CL 
+| parse RawData with Date " " Time " " CIP " " CSUserName " " SSiteName " " SComputerName " " SIP " " SPort " " CSMethod " " CSUriStem " " csuriquery " " scstatus " " scwin32status " " scbytes " " csbytes " " timetaken " " csversion " " cshost " " csUserAgent " " csCookie " " csReferer


### PR DESCRIPTION
If you are using the custom logs feature to parse a space separated log file, such as the IIS SMTP log file, you can spearate out the different fields using the Parse command in this example. 
It can easily be adapted to other logs, with other separators.