### PR TITLE
Fix embedded image links in log-analytics examples

### DIFF
--- a/log-analytics/server-availability-rate.md
+++ b/log-analytics/server-availability-rate.md
@@ -44,7 +44,7 @@ Note that this way we give a little leeway for missing heartbeat reports each ho
 Instead of expecting a report every 5 or 10 minutes, we only mark a computer as "unavailable" if we didn't get any report from it during a full hour.
 
 At this point we get a number for each computer, something like this:
-<p><img src="~/examples/images/availability-hours.png" alt="server availability hours"></p>
+![server availability hours](https://github.com/MicrosoftDocs/LogAnalyticsExamples/blob/master/images/availability-hours.png)
 
 So we know the number of hours each computer was available during the set time range. But what does it mean? how many hours were there altogether?
 
@@ -61,5 +61,5 @@ Finally we calculate the ratio between available hours and total hours:
 ```
 and get this:
 
-<p><img src="~/examples/images/availability-rate.png" alt="server availability rate"></p>
+![server availability rate](https://github.com/MicrosoftDocs/LogAnalyticsExamples/blob/master/images/availability-rate.png)
 

--- a/smart-analytics/sliding-window-calculations-cohort-analysis.md
+++ b/smart-analytics/sliding-window-calculations-cohort-analysis.md
@@ -83,4 +83,4 @@ week
 ```
 
 The output will look like this:
-<p><img src="~/examples/images/cohorts.png" alt="cohorts"></p>
+![cohorts](https://github.com/MicrosoftDocs/LogAnalyticsExamples/blob/master/images/cohorts.png)

--- a/smart-analytics/sliding-window-calculations-rolling-mau.md
+++ b/smart-analytics/sliding-window-calculations-rolling-mau.md
@@ -60,4 +60,4 @@ customEvents
 ```
 
 The output will look like this:
-<p><img src="~/examples/images/rolling-mau.png" alt="rolling mau"></p>
+![rolling mau](https://github.com/MicrosoftDocs/LogAnalyticsExamples/blob/master/images/rolling-mau.png)

--- a/smart-analytics/sliding-window-calculations-user-stickiness.md
+++ b/smart-analytics/sliding-window-calculations-user-stickiness.md
@@ -50,4 +50,4 @@ on Timestamp
 ```
 
 The output will look like this:
-<p><img src="~/examples/images/user-stickiness.png" alt="user stickiness"></p>
+![user stickiness](https://github.com/MicrosoftDocs/LogAnalyticsExamples/blob/master/images/user-stickiness.png)


### PR DESCRIPTION
Fixed the syntax from what looked to be HTML to markdown, and pointed the images at the correct location in the repo so the examples now have sample outputs to look at.